### PR TITLE
Only skip CSRF protection in voice feedbacks controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  #protect_from_forgery with: :exception
+  protect_from_forgery with: :exception
+
   before_filter :authenticate if ENV["LOCK_CITYVOICE"] == "true"
   before_filter :load_app_content
 

--- a/app/controllers/voice_feedback_controller.rb
+++ b/app/controllers/voice_feedback_controller.rb
@@ -1,4 +1,5 @@
 class VoiceFeedbackController < ApplicationController
+  skip_before_action :verify_authenticity_token
 
   def route_to_survey
     @call_in_code_digits = AppContentSet.select(:call_in_code_digits).first.call_in_code_digits


### PR DESCRIPTION
Upcoming features will need `authenticity_token` verified according to discussions with @daguar and @rduecyg.
