### PR TITLE
Expand test coverage for messages

### DIFF
--- a/app/views/feedback_inputs/voice_messages.html.erb
+++ b/app/views/feedback_inputs/voice_messages.html.erb
@@ -27,8 +27,8 @@
     <div class="row" style="margin-top: 2em;">
       <div class="span2 offset1">
         <h3>
-          <% if location %>
-            <a href="<%= "subjects/#{location.gsub(" ","-")} " %>"><%= location %></a>
+          <% if message.subject %>
+            <a href="<%= message.subject.url_to %>"><%= message.subject.name %></a>
           <% end %>
         </h3>
       </div>
@@ -36,7 +36,11 @@
         <h3><%= created_at %></h3>
       </div>
       <div class="span2">
-        <h3><%= phone %> </h3>
+        <h3>
+          <% if message.phone_number.present? %>
+            <%= "XXX-XXX-#{message.phone_number.to_s[-4..-1]}" %>
+          <% end %>
+        </h3>
       </div>
       <div class="span5">
        <style>

--- a/app/views/subjects/_feedback.html.erb
+++ b/app/views/subjects/_feedback.html.erb
@@ -27,7 +27,7 @@
 												<strong><%= @choice %></strong>&nbsp;&nbsp;
 											  date: <strong><%= message.created_at.to_date %></strong> &nbsp;
                         <% if message.phone_number.present? %>
-											   from: <strong><%= "XXX-XXX-" + message.phone_number.to_s[-4..-1] %></strong>
+											   from: <strong><%= "XXX-XXX-#{message.phone_number.to_s[-4..-1]}" %></strong>
                         <% end %>
 											</div>
 											<div>

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -4,6 +4,8 @@ describe 'Listening to messages' do
   let(:create_date) { Time.zone.now }
   let(:property) { create(:subject, name: '1313 Mockingbird Lane') }
   let!(:feedback_input) { create(:feedback_input, :with_voice_file, subject: property, created_at: create_date) }
+  let(:number_question) { create(:question, :number) }
+  let!(:numeric_input) { create(:feedback_input, numerical_response: '1', question: number_question, subject: property, created_at: create_date) }
 
   context 'on the landing page' do
     before do
@@ -46,6 +48,62 @@ describe 'Listening to messages' do
 
     it 'has the feedback input audio file' do
       expect(page).to have_selector(%|source[src='#{feedback_input.voice_file_url}.mp3']|)
+    end
+
+    context 'when the user has not consented to publicly display their number' do
+      let!(:feedback_input) { create(:feedback_input, :with_voice_file, phone_number: nil, subject: property, created_at: create_date) }
+
+      it 'does not display a number' do
+        expect(page).not_to have_content('XXX-XXX-')
+      end
+    end
+  end
+
+  context 'on the activity page' do
+    before do
+      visit most_feedback_path
+    end
+
+    it 'shows name of the location' do
+      expect(page).to have_content('1313 Mockingbird Lane')
+    end
+
+    it 'shows the total number of votes' do
+      expect(page).to have_content('1')
+    end
+
+    it 'shows the number of repair votes' do
+      expect(page).to have_content('repair 1')
+    end
+
+    it 'shows the number of remove votes' do
+      expect(page).to have_content('remove 0')
+    end
+  end
+
+  context 'on the voice message summary page' do
+    before do
+      visit voice_messages_path
+    end
+
+    it 'shows name of the location' do
+      expect(page).to have_content('1313 Mockingbird Lane')
+    end
+
+    it 'shows the date the call was made' do
+      expect(page).to have_content(create_date.strftime('%Y-%m-%d'))
+    end
+
+    it 'displays audio player' do
+      expect(page).to have_selector('audio')
+    end
+
+    it 'has the feedback input audio file' do
+      expect(page).to have_selector(%|source[src='#{feedback_input.voice_file_url}.mp3']|)
+    end
+
+    it 'shows the masked number from which the call was made' do
+      expect(page).to have_content('XXX-XXX-1212')
     end
 
     context 'when the user has not consented to publicly display their number' do


### PR DESCRIPTION
This wraps integration tests around both the voice message summary page and the activity page.
