### PR TITLE
Location URL Fixup

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,7 +4,7 @@ class LocationsController < ApplicationController
   end
 
   def show
-    @location = Location.find_by_param(params[:id])
+    @location = Location.find(params[:id])
     @numerical_responses = @location.numerical_responses
     @numerical_responses_exist = @location.has_numerical_responses?
     @user_voice_messages = @location.voice_messages

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -25,14 +25,6 @@ class Location < ActiveRecord::Base
     where('most_recent_activity >= ?', time)
   end
 
-  def self.find_by_param(param)
-    if param =~ /^[0-9]+$/
-      find(param)
-    else
-      find_by!(name: param.gsub('-', ' '))
-    end
-  end
-
   def property_code
     digits = Rails.application.config.app_content_set.call_in_code_digits.to_i
     self.id.to_s.rjust(digits, '0')
@@ -59,7 +51,7 @@ class Location < ActiveRecord::Base
   end
 
   def to_param
-    name.gsub(' ', '-')
+    "#{self.id}-#{self.name.parameterize}"
   end
 
   def point

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -51,7 +51,7 @@
       displayKey: 'name',
       source: locations.ttAdapter()
     }).on('typeahead:selected', function(e, data, dataset){
-      window.location = '<%= locations_url %>/' + data.name.replace(/\s+/g, '-');
+      window.location = data.url;
     });
   });
 </script>

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -38,9 +38,9 @@ describe LocationsController do
   end
 
   describe 'GET #show' do
-    let!(:location) { create(:location, name: '123 Main Street', lat: 1, long: 2) }
+    let!(:location) { create(:location, id: 333, name: '123 Main Street', lat: 1, long: 2) }
 
-    def make_request(location_id = location.id)
+    def make_request(location_id = location.to_param)
       get :show, id: location_id
     end
 
@@ -107,7 +107,7 @@ describe LocationsController do
     end
 
     context 'when requesting a location by name' do
-      before { make_request('123-Main-Street') }
+      before { make_request('333-123-Main-Street') }
 
       its(:response) { should be_success }
 
@@ -117,7 +117,7 @@ describe LocationsController do
     end
 
     context 'when requesting json' do
-      def make_request(location_id = location.id)
+      def make_request(location_id = location.to_param)
         get :show, id: location_id, format: :json
       end
 
@@ -143,7 +143,7 @@ describe LocationsController do
           expect(JSON.parse(response.body)['geometry']).to include('coordinates' => [2, 1])
           expect(JSON.parse(response.body)).to have_key('properties')
           expect(JSON.parse(response.body)['properties']).to include('name' => '123 Main Street')
-          expect(JSON.parse(response.body)['properties']).to include('url' => 'http://test.host/locations/123-Main-Street')
+          expect(JSON.parse(response.body)['properties']).to include('url' => 'http://test.host/locations/333-123-main-street')
         end
 
         it 'saves the fixture' do

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Listening to messages' do
   let(:create_date) { Time.zone.now }
-  let(:location) { create(:location, name: '1313 Mockingbird Lane') }
+  let(:location) { create(:location, id: 333, name: "O'Brien Park/Skate Park") }
   let(:caller) { create(:caller, phone_number: '+14155551212') }
   let(:call) { create(:call, location: location, caller: caller, consented_to_callback: true) }
   let!(:answer) { create(:answer, :voice_file, call: call, created_at: create_date) }
@@ -15,7 +15,7 @@ describe 'Listening to messages' do
     end
 
     it 'shows name of the location' do
-      expect(page).to have_content('1313 Mockingbird Lane')
+      expect(page).to have_content("O'Brien Park/Skate Park")
     end
 
     it 'shows the date the call was made' do
@@ -33,7 +33,7 @@ describe 'Listening to messages' do
 
   context 'on a location page' do
     before do
-      visit location_path('1313-Mockingbird-Lane')
+      visit location_path('333-o-brien-park-skate-park')
     end
 
     it 'shows the date the call was made' do
@@ -74,7 +74,7 @@ describe 'Listening to messages' do
     end
 
     it 'shows name of the location' do
-      expect(page).to have_content('1313 Mockingbird Lane')
+      expect(page).to have_content("O'Brien Park/Skate Park")
     end
 
     it 'shows the total number of votes' do
@@ -96,7 +96,7 @@ describe 'Listening to messages' do
     end
 
     it 'shows name of the location' do
-      expect(page).to have_content('1313 Mockingbird Lane')
+      expect(page).to have_content("O'Brien Park/Skate Park")
     end
 
     it 'shows the date the call was made' do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe NotificationMailer do
-  let(:location) { create(:location, name: '1313 mockingbird lane') }
+  let(:location) { create(:location, id: 333, name: '1313 mockingbird lane') }
   let(:subscriber) { create(:subscriber, email: 'tacos@example.com') }
   let!(:location_subscription) { create(:location_subscription, subscriber: subscriber, location: location) }
 
@@ -52,7 +52,7 @@ describe NotificationMailer do
     end
 
     it 'assigns @properties_array' do
-      mail.body.encoded.should include('localhost:3000/locations/1313-mockingbird-lane')
+      mail.body.encoded.should include('localhost:3000/locations/333-1313-mockingbird-lane')
     end
 
     it 'assigns @unsubscribe_all_token' do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -17,7 +17,7 @@ require 'spec_helper'
 describe Location do
   let(:call) { create(:call, location: location) }
 
-  subject(:location) { create(:location, name: '123 Maple Street', lat: 38, long: 122) }
+  subject(:location) { create(:location, id: 333, name: '123 Maple Street', lat: 38, long: 122) }
 
   it { should validate_presence_of(:name) }
 
@@ -31,33 +31,9 @@ describe Location do
   it { should allow_mass_assignment_of(:description) }
   it { should allow_mass_assignment_of(:most_recent_activity) }
 
-  its(:to_param) { should == '123-Maple-Street' }
+  its(:to_param) { should == '333-123-maple-street' }
 
   its(:point) { should == [122, 38] }
-
-  describe '.find_by_param' do
-    let!(:location) { create(:location, name: '123 Maple Street') }
-
-    context 'when the location exists' do
-      it 'finds the location by id' do
-        expect(Location.find_by_param(location.id.to_s)).to eq(location)
-      end
-
-      it 'finds the location by name with dashes' do
-        expect(Location.find_by_param('123-Maple-Street')).to eq(location)
-      end
-    end
-
-    context 'when the location does not exist' do
-      it 'blows up when finding by id' do
-        expect { Location.find_by_param('0') }.to raise_error
-      end
-
-      it 'blows up when finding by name' do
-        expect { Location.find_by_param('Taco-Trucks') }.to raise_error
-      end
-    end
-  end
 
   describe '.activity_since' do
     let!(:location) { create(:location, most_recent_activity: Time.now) }


### PR DESCRIPTION
I changed URLS on locations to take advantage of a little Rails URL routing magic. It simplifies some of the location lookup and handles funky characters like `'` and `\` a bit better in exchange for a crufty set of digits before the title.