### PR TITLE
Use Python for secret token setting in deployment (installed by default ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ Create a Heroku app:
     
 Set the secret token:
 
-    $ heroku config:set SECRET_TOKEN=`rake secret`
-
-(If you don't have Ruby installed and this command gives you errors, you can replace \`rake secret\` by typing in at least 30 random characters string, for example: `SECRET_TOKEN=8ausfkjhasdfkjshdfkjaisufyasfasdkjfskdjfh`.)
+    $ heroku config:set SECRET_TOKEN=`python -c 'import uuid; print uuid.uuid4()'`
 
 Next, push the code to Heroku:
 


### PR DESCRIPTION
...on OSX and Ubuntu)

Addresses @migurski's comments here: https://github.com/codeforamerica/cityvoice/pull/196#issuecomment-48776143

We discussed it, and the goal here is that blindly copying/pasting the deployment commands into a terminal should Just Work™.

This doesn't solve the problem for Windows users, but it _does_ eliminate the need for a redeployer to install anything beyond Git and the Heroku toolbelt. Since we envision having a "CityVoice Provisioner" micro-app to build instances for non-technical users, this seems like the path of least resistance.

(I've tested that this method of setting the token works in production on Heroku.)
